### PR TITLE
Swap out switch statement for ternary operator with 1 check

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -45,30 +45,10 @@ export default class Middleware {
 
   runRoute(route, routeCheck, req, res) {
     const self = this;
-    switch (req.method) {
-      case 'POST':
-        route.post.emit(routeCheck.route, req, res);
-        break;
 
-      case 'GET':
-        route.get.emit(routeCheck.route, req, res);
-        break;
+    const methods = ['post', 'get', 'put', 'delete', 'options'],
+          method  = req.method.toLowerCase();
 
-      case 'PUT':
-        route.put.emit(routeCheck.route, req, res);
-        break;
-
-      case 'DELETE':
-        route.delete.emit(routeCheck.route, req, res);
-        break;
-
-      case 'OPTIONS':
-        route.options.emit(routeCheck.route, req, res);
-        break;
-
-      default:
-        res.writeHead(404);
-        break;
-    }
+    methods.indexOf(method) > -1 ? route[method].emit(routeCheck.route, req, res) : res.writeHead(404);
   }
 }


### PR DESCRIPTION
Switch statement was checking for multiple cases, this solution only has 1 check since each case runs the same code except for the method it calls, which is based on the method passed through. So transform it to lowercase and access it through the array/object key.